### PR TITLE
pin conda-build to 1.21.7 to build obspy 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
+      conda install --yes conda-build=1.21.7  # revert conda-build to 1.21.7, to get ObsPy 1.0.2 built, see conda-forge/staged-recipes#582
 
 script:
   - conda build ./recipe

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,6 +41,9 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+# revert conda-build to 1.21.7, to get ObsPy 1.0.2 built, see conda-forge/staged-recipes#582
+conda install --yes conda-build=1.21.7
+
 # Embarking on 3 case(s).
     set -x
     export CONDA_PY=27


### PR DESCRIPTION
See conda-forge/staged-recipes#582, build fails with current conda-build 1.21.9
