### PR TITLE
Build next ObsPy release (do not merge yet)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ install:
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
-      conda install --yes conda-build=1.21.7  # revert conda-build to 1.21.7, to get ObsPy 1.0.2 built, see conda-forge/staged-recipes#582
 
 script:
   - conda build ./recipe

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,9 +41,6 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# revert conda-build to 1.21.7, to get ObsPy 1.0.2 built, see conda-forge/staged-recipes#582
-conda install --yes conda-build=1.21.7
-
 # Embarking on 3 case(s).
     set -x
     export CONDA_PY=27


### PR DESCRIPTION
This is just preparation to build the next ObsPy release, currently only contains reverting the pinning of conda-build (so we don't forget about it later) that was temporarily needed to get the first build and won't be necessary once conda-build 1.21.11 is released.
# DO NOT MERGE YET
