### PR TITLE
Build next ObsPy release 1.0.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,14 @@ install:
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
 
+      # install conda-build 2.x to build with a long prefix
+      conda install --yes --quiet conda-build=2
+      conda info
+
 script:
   - conda build ./recipe
 
   - upload_or_check_non_existence ./recipe conda-forge --channel=main
+
+  # inspect the prefix lengths of the built packages
+  - conda inspect prefix-lengths /Users/travis/miniconda3/conda-bld/osx-64/*.tar.bz2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: ObsPy: A Python Toolbox for seismology/seismological observatories.
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/obspy-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/obspy-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/obspy-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/obspy-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/obspy-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/obspy-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/obspy/badges/version.svg)](https://anaconda.org/conda-forge/obspy)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/obspy/badges/downloads.svg)](https://anaconda.org/conda-forge/obspy)
+
 Installing obspy
 ================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `obspy` available on your platform
 ```
 conda search obspy --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/obspy-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/obspy-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/obspy-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/obspy-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/obspy-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/obspy-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/obspy/badges/version.svg)](https://anaconda.org/conda-forge/obspy)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/obspy/badges/downloads.svg)](https://anaconda.org/conda-forge/obspy)
 
 
 Updating obspy-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,11 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +16,27 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,24 +57,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,6 +41,10 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+# install conda-build 2.x to build a long prefix
+conda install --yes --quiet conda-build=2
+conda info
+
 # Embarking on 3 case(s).
     set -x
     export CONDA_PY=27
@@ -59,4 +63,7 @@ source run_conda_forge_build_setup
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+# inspect the prefix lengths of the built packages
+conda inspect prefix-lengths /feedstock_root/build_artefacts/linux-64/*.tar.bz2
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
-{% set version = "1.0.2" %}
-{% set sha256 = "37d563e36a44a5309b2f53b394d7391d49c8a62b0e8d0f0d13f54ea4e2943230" %}
-# {% set md5 = "b1432aa11b6d244c4fac61737c0c9d95" %}
+{% set version = "1.0.3rc1" %}
+{% set sha256 = "70899fa5b7d11bd09287ade363323dd3718133b59def1fb0d773e8fc57d68136" %}
 
 package:
   name: obspy
@@ -8,14 +7,13 @@ package:
 
 source:
   fn: obspy-{{ version }}.zip
-  url: https://pypi.io/packages/source/o/obspy/obspy-1.0.2.zip
+  # url: https://pypi.io/packages/source/o/obspy/obspy-1.0.2.zip
+  url: https://github.com/obspy/obspy/files/796697/obspy-1.0.3rc1.zip
   sha256: {{ sha256 }}
-#  url: https://www.geophysik.uni-muenchen.de/%7Emegies/obspy-{{ version }}.zip
-#  md5: {{ md5 }}
 
 
 build:
-  number: 1
+  number: 0
   preserve_egg_dir: yes
   detect_binary_files_with_prefix: true
   script: python setup.py install --single-version-externally-managed --record record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.0.3rc1" %}
-{% set sha256 = "70899fa5b7d11bd09287ade363323dd3718133b59def1fb0d773e8fc57d68136" %}
+{% set version = "1.0.3" %}
+{% set sha256 = "7170c7427471f978f7a7b0fe61c2bfb7094c59b3859cd8d5d5bbae6380cc20a5" %}
 
 package:
   name: obspy
@@ -7,8 +7,8 @@ package:
 
 source:
   fn: obspy-{{ version }}.zip
-  # url: https://pypi.io/packages/source/o/obspy/obspy-1.0.2.zip
-  url: https://github.com/obspy/obspy/files/796697/obspy-1.0.3rc1.zip
+  url: https://pypi.io/packages/source/o/obspy/obspy-1.0.3.zip
+  # url: https://github.com/obspy/obspy/files/796697/obspy-1.0.3rc1.zip
   sha256: {{ sha256 }}
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,27 +25,31 @@ requirements:
     - future
     - numpy
     - scipy
-    - matplotlib
+    # the pinning of matplotlib for tests should be removed for later commits
+    # after merging obspy/obspy#1616
+    - matplotlib 1.5.*
     - lxml
     - sqlalchemy
     - requests
     - decorator
     # there's a packaging problem with icu, see obspy/obspy#1677
-    - icu <58
+    - icu 58.*
   run:
     - python
     - setuptools
     - future
     - numpy
     - scipy
-    - matplotlib
+    # the pinning of matplotlib for tests should be removed for later commits
+    # after merging obspy/obspy#1616
+    - matplotlib 1.5.*
     - lxml
     - sqlalchemy
     - requests
     - decorator
     - mock  # [py2k]
     # there's a packaging problem with icu, see obspy/obspy#1677
-    - icu <58
+    - icu 58.*
 
 test:
   requires:
@@ -54,7 +58,7 @@ test:
     # after merging obspy/obspy#1616
     - matplotlib 1.5.*
     # there's a packaging problem with icu, see obspy/obspy#1677
-    - icu <58
+    - icu 58.*
   imports:
     - obspy
     - obspy.io.mseed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,8 @@ requirements:
     - sqlalchemy
     - requests
     - decorator
+    # there's a packaging problem with icu, see obspy/obspy#1677
+    - icu <58
   run:
     - python
     - setuptools
@@ -42,6 +44,8 @@ requirements:
     - requests
     - decorator
     - mock  # [py2k]
+    # there's a packaging problem with icu, see obspy/obspy#1677
+    - icu <58
 
 test:
   requires:
@@ -49,6 +53,8 @@ test:
     # the pinning of matplotlib for tests should be removed for later commits
     # after merging obspy/obspy#1616
     - matplotlib 1.5.*
+    # there's a packaging problem with icu, see obspy/obspy#1677
+    - icu <58
   imports:
     - obspy
     - obspy.io.mseed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,9 @@ requirements:
 test:
   requires:
     - flake8
+    # the pinning of matplotlib for tests should be removed for later commits
+    # after merging obspy/obspy#1616
+    - matplotlib 1.5.*
   imports:
     - obspy
     - obspy.io.mseed


### PR DESCRIPTION
~~Currently only reverts the pinning of conda-build.~~
~~For the next release, commit to this branch at obspy/obspy-feedstock filling in the new URL and SHA256 of the next release tarball.~~

~~Do not merge yet~~

Ready for merging when CI passes.
