### PR TITLE
Adding mock to runtime dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   preserve_egg_dir: yes
   detect_binary_files_with_prefix: true
   script: python setup.py install --single-version-externally-managed --record record.txt
@@ -43,10 +43,10 @@ requirements:
     - sqlalchemy
     - requests
     - decorator
+    - mock  # [py2k]
 
 test:
   requires:
-    - mock  # [py2k]
     - flake8
   imports:
     - obspy


### PR DESCRIPTION
Adds mock as a runtime dependency. Thus errors such as https://github.com/obspy/obspy/issues/1521 will no longer happen. I've seen it twice already and it is confusing to tell people that they have to install mock when they want to run the tests.
