### PR TITLE
build obspy 1.1.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,6 @@
 
 environment:
 
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script intepreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
@@ -67,7 +62,6 @@ install:
     - cmd: conda config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
@@ -75,6 +69,6 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build recipe --quiet"
+    - conda build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,16 +24,30 @@ show_channel_urls: true
 CONDARC
 )
 
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
 rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
 
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
+                        -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1
 
+set -e
+set +x
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
+set -x
 export PYTHONUNBUFFERED=1
 
 echo "$config" > ~/.condarc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.1.0rc6" %}
-{% set sha256 = "0a09a198bd48b32b445d9a307202a26d12f8f057a67ee836f483c6a88b423b4e" %}
+{% set version = "1.1.0rc8" %}
+{% set sha256 = "686b2d4364ed4d93cd21c13e17751e3867d30c1428f060544fb2c28c04d7bab2" %}
 
 package:
   name: obspy
@@ -8,7 +8,7 @@ package:
 source:
   fn: obspy-{{ version }}.zip
   # url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
-  url: https://github.com/obspy/obspy/files/1391402/obspy-1.1.0rc6.zip
+  url: https://github.com/obspy/obspy/files/1410615/obspy-1.1.0rc8.zip
   sha256: {{ sha256 }}
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,11 @@ test:
     - obspy.io.mseed
   commands:
     - python -c "from obspy import read;"
+    # test at least a few executables that should've bben installed
+    - obspy-print -h
+    - obspy-plot -h
+    - obspy-runtests -h
+    - obspy-scan -h
 
 about:
   home: https://obspy.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.1.0rc9" %}
-{% set sha256 = "cb0fce24e9a9542ec1b3a9bbf1bacac97cf89e7aa2adfae87e55fea2d96848c7" %}
+{% set version = "1.1.0rc10" %}
+{% set sha256 = "19a4dfa8ad1a587ce304a79dc2f93e27edbfdd0d03cc2f07359282f77e9901da" %}
 
 package:
   name: obspy
@@ -8,7 +8,7 @@ package:
 source:
   fn: obspy-{{ version }}.zip
   # url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
-  url: https://github.com/obspy/obspy/files/1411439/obspy-1.1.0rc9.zip
+  url: https://www.dropbox.com/s/d92npjvy17yklma/obspy-1.1.0rc10.zip?dl=1
   sha256: {{ sha256 }}
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.1.0rc8" %}
-{% set sha256 = "686b2d4364ed4d93cd21c13e17751e3867d30c1428f060544fb2c28c04d7bab2" %}
+{% set version = "1.1.0rc9" %}
+{% set sha256 = "cb0fce24e9a9542ec1b3a9bbf1bacac97cf89e7aa2adfae87e55fea2d96848c7" %}
 
 package:
   name: obspy
@@ -8,7 +8,7 @@ package:
 source:
   fn: obspy-{{ version }}.zip
   # url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
-  url: https://github.com/obspy/obspy/files/1410615/obspy-1.1.0rc8.zip
+  url: https://github.com/obspy/obspy/files/1411439/obspy-1.1.0rc9.zip
   sha256: {{ sha256 }}
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.1.0rc4" %}
-{% set sha256 = "fdc2149eed1de345e6ff23726657da5f124bebf93393fbb354ff2cb4b160b1ef" %}
+{% set version = "1.1.0rc6" %}
+{% set sha256 = "0a09a198bd48b32b445d9a307202a26d12f8f057a67ee836f483c6a88b423b4e" %}
 
 package:
   name: obspy
@@ -8,7 +8,7 @@ package:
 source:
   fn: obspy-{{ version }}.zip
   # url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
-  url: https://github.com/obspy/obspy/files/1389201/obspy-1.1.0rc4.zip
+  url: https://github.com/obspy/obspy/files/1391402/obspy-1.1.0rc6.zip
   sha256: {{ sha256 }}
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.1.0rc3" %}
-{% set sha256 = "f9d335ce14aa393223068985f71aec1a6f5cea4cdf8a901438cf3e3bdb12f29e" %}
+{% set version = "1.1.0rc4" %}
+{% set sha256 = "fdc2149eed1de345e6ff23726657da5f124bebf93393fbb354ff2cb4b160b1ef" %}
 
 package:
   name: obspy
@@ -8,7 +8,7 @@ package:
 source:
   fn: obspy-{{ version }}.zip
   # url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
-  url: https://github.com/obspy/obspy/files/1388499/obspy-1.1.0rc3.zip
+  url: https://github.com/obspy/obspy/files/1389201/obspy-1.1.0rc4.zip
   sha256: {{ sha256 }}
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.0.3" %}
-{% set sha256 = "7170c7427471f978f7a7b0fe61c2bfb7094c59b3859cd8d5d5bbae6380cc20a5" %}
+{% set sha256 = "XXX" %}
 
 package:
   name: obspy
@@ -7,7 +7,7 @@ package:
 
 source:
   fn: obspy-{{ version }}.zip
-  url: https://pypi.io/packages/source/o/obspy/obspy-1.0.3.zip
+  url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
   # url: https://github.com/obspy/obspy/files/796697/obspy-1.0.3rc1.zip
   sha256: {{ sha256 }}
 
@@ -32,8 +32,6 @@ requirements:
     - sqlalchemy
     - requests
     - decorator
-    # there's a packaging problem with icu, see obspy/obspy#1677
-    - icu 58.*
   run:
     - python
     - setuptools
@@ -48,8 +46,6 @@ requirements:
     - requests
     - decorator
     - mock  # [py2k]
-    # there's a packaging problem with icu, see obspy/obspy#1677
-    - icu 58.*
 
 test:
   requires:
@@ -57,8 +53,6 @@ test:
     # the pinning of matplotlib for tests should be removed for later commits
     # after merging obspy/obspy#1616
     - matplotlib 1.5.*
-    # there's a packaging problem with icu, see obspy/obspy#1677
-    - icu 58.*
   imports:
     - obspy
     - obspy.io.mseed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.1.0rc11" %}
-{% set sha256 = "b2a3d4bc35c5e1c3c70c31aec4e8ff8cfe030681feda0b7c93d82d9a155f6123" %}
+{% set version = "1.1.0" %}
+{% set sha256 = "ef48b4e52a8166c35c46775b523899ffaa00658018822103e1ad9f5008050d61" %}
 
 package:
   name: obspy
@@ -7,8 +7,7 @@ package:
 
 source:
   fn: obspy-{{ version }}.zip
-  # url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
-  url: https://www.dropbox.com/s/zrxb5uvncsokxg8/obspy-1.1.0rc11.zip?dl=1
+  url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
   sha256: {{ sha256 }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,7 @@ test:
     # the pinning of matplotlib for tests should be removed for later commits
     # after merging obspy/obspy#1616
     - matplotlib 1.5.*
+    - pyshp
   imports:
     - obspy
     - obspy.io.mseed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.1.0rc11" %}
-{% set sha256 = "07493250110af77b84843683592ce6c27bc5c6c27d5a530df180ead7ce05e413" %}
+{% set sha256 = "b2a3d4bc35c5e1c3c70c31aec4e8ff8cfe030681feda0b7c93d82d9a155f6123" %}
 
 package:
   name: obspy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,7 @@ requirements:
     - future
     - numpy
     - scipy
-    # the pinning of matplotlib for tests should be removed for later commits
-    # after merging obspy/obspy#1616
-    - matplotlib 1.5.*
+    - matplotlib
     - lxml
     - sqlalchemy
     - requests
@@ -38,9 +36,7 @@ requirements:
     - future
     - numpy
     - scipy
-    # the pinning of matplotlib for tests should be removed for later commits
-    # after merging obspy/obspy#1616
-    - matplotlib 1.5.*
+    - matplotlib
     - lxml
     - sqlalchemy
     - requests
@@ -50,9 +46,7 @@ requirements:
 test:
   requires:
     - flake8
-    # the pinning of matplotlib for tests should be removed for later commits
-    # after merging obspy/obspy#1616
-    - matplotlib 1.5.*
+    - matplotlib
     - pyshp
   imports:
     - obspy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.0.3" %}
-{% set sha256 = "XXX" %}
+{% set version = "1.1.0rc2" %}
+{% set sha256 = "c80dcdf9da77693a097e61a5c63a11a05e3e6126736a047949f5029477fc671a" %}
 
 package:
   name: obspy
@@ -7,8 +7,8 @@ package:
 
 source:
   fn: obspy-{{ version }}.zip
-  url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
-  # url: https://github.com/obspy/obspy/files/796697/obspy-1.0.3rc1.zip
+  # url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
+  url: https://github.com/obspy/obspy/files/1387266/obspy-1.1.0rc2.zip
   sha256: {{ sha256 }}
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.1.0rc2" %}
-{% set sha256 = "c80dcdf9da77693a097e61a5c63a11a05e3e6126736a047949f5029477fc671a" %}
+{% set version = "1.1.0rc3" %}
+{% set sha256 = "f9d335ce14aa393223068985f71aec1a6f5cea4cdf8a901438cf3e3bdb12f29e" %}
 
 package:
   name: obspy
@@ -8,7 +8,7 @@ package:
 source:
   fn: obspy-{{ version }}.zip
   # url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
-  url: https://github.com/obspy/obspy/files/1387266/obspy-1.1.0rc2.zip
+  url: https://github.com/obspy/obspy/files/1388499/obspy-1.1.0rc3.zip
   sha256: {{ sha256 }}
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.1.0rc10" %}
-{% set sha256 = "19a4dfa8ad1a587ce304a79dc2f93e27edbfdd0d03cc2f07359282f77e9901da" %}
+{% set version = "1.1.0rc11" %}
+{% set sha256 = "07493250110af77b84843683592ce6c27bc5c6c27d5a530df180ead7ce05e413" %}
 
 package:
   name: obspy
@@ -8,9 +8,8 @@ package:
 source:
   fn: obspy-{{ version }}.zip
   # url: https://pypi.io/packages/source/o/obspy/obspy-{{ version }}.zip
-  url: https://www.dropbox.com/s/d92npjvy17yklma/obspy-1.1.0rc10.zip?dl=1
+  url: https://www.dropbox.com/s/zrxb5uvncsokxg8/obspy-1.1.0rc11.zip?dl=1
   sha256: {{ sha256 }}
-
 
 build:
   number: 1

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 import matplotlib
 matplotlib.use("AGG")
@@ -8,6 +9,11 @@ from obspy.core import run_tests
 os.environ["CONDAFORGE"] = ''
 # set env variable to skip code formatting checks
 os.environ["OBSPY_NO_FLAKE8"] = ''
+# this is embarassing.. APPVEYOR env variable is not set as it should be
+# according to appveyor docs (see
+# https://ci.appveyor.com/project/conda-forge/obspy-feedstock/build/1.0.37/job/cn9436iry5nl9nj6#L5903)
+if platform.system().lower() == 'windows':
+    os.environ["APPVEYOR"] = "True"
 # check environment settings
 print("'CONDAFORGE' in env: {}".format(str("CONDAFORGE" in os.environ)))
 print("'APPVEYOR' in env: {}".format(str("APPVEYOR" in os.environ)))

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -8,6 +8,11 @@ from obspy.core import run_tests
 os.environ["CONDAFORGE"] = ''
 # set env variable to skip code formatting checks
 os.environ["OBSPY_NO_FLAKE8"] = ''
+# check environment settings
+print("'CONDAFORGE' in env: {}".format(str("CONDAFORGE" in os.environ)))
+print("'APPVEYOR' in env: {}".format(str("APPVEYOR" in os.environ)))
+if "APPVEYOR" in os.environ:
+    print("'APPVEYOR' env setting: '{}'".format(os.environ['APPVEYOR']))
 # run tests and send test report
 errors = run_tests(report=True, hostname="conda-forge", verbosity=2)
 if errors:


### PR DESCRIPTION
This is the PR for the next ObsPy release via conda-forge, which will likely take some more weeks or months even.

Currently this is only revert the pinning of `icu` package, just as a reminder.

TODO:
- [x] Rebase on current master (which was re-rendered in #13)
- [x] ~~Include Python 3.4 in build matrix again (which somehow was removed by re-rendering in #13)~~ **EDIT:** conda-forge does not support building for Python 3.4 anymore, see https://github.com/conda-forge/conda-smithy/issues/496#issuecomment-289429774)
- [x] Add tests for command line scripts (see https://github.com/conda-forge/staged-recipes/pull/3955#issuecomment-330557420)

## Do not merge yet