### PR TITLE
add basemap as dependency for obspy packages built on conda-forge

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   preserve_egg_dir: yes
   detect_binary_files_with_prefix: true
   script: python setup.py install --single-version-externally-managed --record record.txt
@@ -40,6 +40,7 @@ requirements:
     - requests
     - decorator
     - mock  # [py2k]
+    - basemap
 
 test:
   requires:


### PR DESCRIPTION
it's available in version 1.1.0 for all platforms/architectures that
conda-forge supports, so it should be available whenever installing
obspy via conda-forge channel.

also these basemap packages are numpy version agnostic nowadays, so it
should not meddle with other obspy dependencies.

see
http://lists.swapbytes.de/archives/obspy-users/2018-March/002706.html