### PR TITLE
Cartopy not basemap

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,12 +41,14 @@ requirements:
     - requests
     - decorator
     - mock  # [py2k]
+    - cartopy
 
 test:
   requires:
     - flake8
     - matplotlib
     - pyshp
+    - cartopy
   imports:
     - obspy
     - obspy.io.mseed


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
### Reasons:
 - Basemap is EOL,
 - and giving me spurious issues. (not fully debugged, but)
 - Cartopy resolves, and is intended as basemaps replacement.
### Refs:
EOL announce:
https://matplotlib.org/basemap/users/intro.html#cartopy-new-management-and-eol-announcement
Some direction discussion:
https://github.com/SciTools/cartopy/issues/920
There was a short discussion on our gitter.

### Disclaimer
This may be heavy handed, and inappropriate, but since this or something similar needs to happen at some point in the future, I figured this would at least see how far cartopy gets us.
