### PR TITLE
Remove pyproj and proj as dependencies

### DIFF
--- a/.ci_support/migrations/python38.yaml
+++ b/.ci_support/migrations/python38.yaml
@@ -1,0 +1,55 @@
+migrator_ts: 1569538102   # The timestamp of when the migration was made
+__migrator: 
+  kind: 
+    version
+  exclude:
+    - c_compiler
+    - vc
+    - cxx_compiler
+  migration_number:  # Only use this if the bot messes up, putting this in will cause a complete rerun of the migration
+    1 
+  bump_number: 0
+
+python:
+  - 2.7
+  - 3.6
+  - 3.7
+  - 3.8
+
+c_compiler:
+  # legacy compilers for things that refuse to move
+  - toolchain_c                # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
+  # modern compilers
+  - gcc                        # [linux64]
+  - clang                      # [osx]
+  # non-standard arches get built with gcc
+  - gcc                        # [aarch64]
+  - gcc                        # [ppc64le]
+  - gcc                        # [armv7l]
+
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+
+cxx_compiler:
+  # legacy compilers for things that refuse to move
+  - toolchain_cxx              # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
+  # modern compilers
+  - gxx                        # [linux64]
+  - clangxx                    # [osx]
+
+  - gxx                        # [aarch64]
+  - gxx                        # [ppc64le]
+  - gxx                        # [armv7l]
+
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+
+vc:                    # [win]
+  - 9                  # [win]
+  - 14                 # [win]
+  - 14                 # [win]
+  - 14                 # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,14 +44,14 @@ requirements:
     - requests
     - decorator
     - mock  # [py2k]
-    - basemap
+    - cartopy
 
 test:
   requires:
     - flake8
     - matplotlib-base
     - pyshp
-    - basemap
+    - cartopy
   imports:
     - obspy
     - obspy.io.mseed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   preserve_egg_dir: yes
   detect_binary_files_with_prefix: true
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
@@ -45,11 +45,6 @@ requirements:
     - decorator
     - mock  # [py2k]
     - basemap
-    # pyproj is a dep of basemap so it does not hurt to include it as dep right
-    # now
-    # dodge proj4 v5 for now, see obspy/obspy#2283
-    - pyproj
-    - proj4 !=5
 
 test:
   requires:


### PR DESCRIPTION
For some reason this seems to be the culprit of ending up in dependency hell so I just removed the `pyproj` and `proj4` dependencies. In the end that is `basemap`'s responsibility and not ObsPy's.

The reason for this change is that a `conda install obspy` right now oftentimes install's ObsPy 1.2.1 if something else also depends on `pyproj`. Also the following command does not work:

```
conda install "obspy>=1.2.1" "pyproj>=2.6.0"
Collecting package metadata: done
Solving environment: failed

UnsatisfiableError: The following specifications were found to be in conflict:
  - obspy[version='>=1.2.1'] -> proj4!=5
  - obspy[version='>=1.2.1'] -> pyproj -> proj[version='>=6.3.1,<6.3.2.0a0']
  - obspy[version='>=1.2.1'] -> pyproj -> python_abi=3.8[build=*_cp38] -> pypy[version='<0a0']
  - pyproj[version='>=2.6.0'] -> proj[version='>=6.3.1,<6.3.2.0a0'] -> proj4==999999999999
  - pyproj[version='>=2.6.0'] -> python_abi=3.8[build=*_cp38] -> pypy[version='<0a0']
Use "conda search <package> --info" to see the dependencies for each package.
```
I have a hard time trying to exactly understand what this means (I especially don't get ` proj4==999999999999`) but in the end ObsPy is not responsible for managing and pinning the dependencies of its dependencies.

@megies Please review